### PR TITLE
Prevent multiple refreshes on game end

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -17,6 +17,7 @@ window.onload = function() {
       collisionHandler.hasCharacterCollided();
     } else if (gameState.props.state === "ended") {
       gameState.handleGameEnd();
+      clearInterval(gameTickLoop);
     }
   }, 1000 / TICKS_PER_SECOND);
 }


### PR DESCRIPTION
This cancels the game tick loop once `location.reload()` has been called.